### PR TITLE
Add RSpec Rake task in order to test without using Guard as per the README

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 
 # Development tools
 gem 'rspec'
+gem 'rake'
 
 gem 'guard'
 gem 'guard-rspec'

--- a/README.md
+++ b/README.md
@@ -293,8 +293,7 @@ Thumbkit.processors['doc'] = 'Doc'
 
 ## Testing
 
-Tests run in guard. If you don't like guard, a pull request on `Rakefile` would
-be welcome.
+Tests run in guard or the default RSpec rake task. `rake` at the command-line will run the tests.
 
 Output files are placed in `spec/tmp` which is created automatically before each
 test run and deleted automatically afterward unless `spec/tmp/.keep` exists. If

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,6 @@
 #!/usr/bin/env rake
 require "bundler/gem_tasks"
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec)
+
+task :default  => :spec


### PR DESCRIPTION
The README said a PR was welcome, so here we are!

`rake` at the command line will run the RSpec tests. I'm not sure if you wanted it to be the default rake task, but I figured it was a start since there wasn't a default one to begin with. I can change it to `rake spec` if that's preferred.
